### PR TITLE
More Makie integration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,24 +52,34 @@ jobs:
       contents: write
       statuses: write
     steps:
+      - name: Install binary dependencies
+        run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/cache@v2
       - name: Configure doc environment
-        shell: julia --project=docs --color=yes {0}
+        shell: xvfb-run -s '-screen 0 1024x768x24' julia --project=docs --color=yes {0}
         run: |
           using Pkg
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
+        env:
+          DISPLAY: ':0'
       - uses: julia-actions/julia-buildpkg@v1
+        with:
+          prefix: xvfb-run -s '-screen 0 1024x768x24'
+        env:
+          DISPLAY: ':0'
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - name: Run doctests
-        shell: julia --project=docs --color=yes {0}
+        shell:  xvfb-run -s '-screen 0 1024x768x24' julia --project=docs --color=yes {0}
+        env: 
+          DISPLAY: ':0'
         run: |
           using Documenter: DocMeta, doctest
           using FlyThroughPaths

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
         run: xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ docs/make.jl deploy
       - name: Run doctests  
         run: julia --project=docs -e '
-          using Documenter: DocMeta, doctest
-          using FlyThroughPaths
-          DocMeta.setdocmeta!(FlyThroughPaths, :DocTestSetup, :(using FlyThroughPaths); recursive=true)
-          doctest(FlyThroughPaths)'
+              using Documenter
+              using FlyThroughPaths
+              Documenter.DocMeta.setdocmeta!(FlyThroughPaths, :DocTestSetup, :(using FlyThroughPaths); recursive=true)
+              Documenter.doctest(FlyThroughPaths)'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
         run: xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ docs/make.jl deploy
       - name: Run doctests  
         run: julia --project=docs -e '
-              using Documenter
-              using FlyThroughPaths
-              Documenter.DocMeta.setdocmeta!(FlyThroughPaths, :DocTestSetup, :(using FlyThroughPaths); recursive=true)
-              Documenter.doctest(FlyThroughPaths)'
+              using Documenter;
+              using FlyThroughPaths;
+              Documenter.DocMeta.setdocmeta!(FlyThroughPaths, :DocTestSetup, :(using FlyThroughPaths); recursive=true);
+              Documenter.doctest(FlyThroughPaths);'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,43 +45,36 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
   docs:
-    name: Documentation
+    name: Build and deploy documentation
     runs-on: ubuntu-latest
-    permissions:
-      actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
-      contents: write
-      statuses: write
     steps:
       - name: Install binary dependencies
         run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+      - uses: julia-actions/setup-julia@latest
         with:
           version: '1'
       - uses: julia-actions/cache@v2
-      - name: Configure doc environment
-        shell: xvfb-run -s '-screen 0 1024x768x24' julia --project=docs --color=yes {0}
+      - name: Install documentation dependencies
         run: |
-          using Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
-          Pkg.instantiate()
+          xvfb-run -s '-screen 0 1024x768x24' julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.add(name = "DocumenterVitepress", rev = "master")
+            Pkg.instantiate()'
         env:
           DISPLAY: ':0'
-      - uses: julia-actions/julia-buildpkg@v1
-        with:
-          prefix: xvfb-run -s '-screen 0 1024x768x24'
+      - name: Build and deploy
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
           DISPLAY: ':0'
-      - uses: julia-actions/julia-docdeploy@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-      - name: Run doctests
-        shell:  xvfb-run -s '-screen 0 1024x768x24' julia --project=docs --color=yes {0}
-        env: 
-          DISPLAY: ':0'
-        run: |
+        run: xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ docs/make.jl deploy
+      - name: Run doctests  
+        run: julia --project=docs -e '
           using Documenter: DocMeta, doctest
           using FlyThroughPaths
           DocMeta.setdocmeta!(FlyThroughPaths, :DocTestSetup, :(using FlyThroughPaths); recursive=true)
-          doctest(FlyThroughPaths)
+          doctest(FlyThroughPaths)'

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You need to load the visualization package, e.g., `using GLMakie`, in your sessi
 
 This can be handy for constructing a path, for example you can interactively set the approximate position and view parameters and then query them for use by the tools above.
 
-```
+```julia
 state = capture_view(scene)
 ```
 
@@ -147,7 +147,7 @@ state = capture_view(scene)
 
 ### Setting the current view state
 
-```
+```julia
 oldstate = set_view!(camera, path, t)
 ```
 
@@ -155,6 +155,6 @@ This updates the current `camera` settings from `path` at time `t`.
 
 ### Displaying the path
 
-```
+```julia
 plot(path)
 ```

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,7 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FlyThroughPaths = "c11bb9a7-2755-425a-88f3-ebe93bbdb91f"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,4 +22,5 @@ makedocs(;
 deploydocs(;
     repo="github.com/HolyLab/FlyThroughPaths.jl",
     devbranch="main",
+    push_preview=true,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,8 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
-        "Makie integration" => "makie.md"
+        "Makie integration" => "makie.md",
+        "Developer documentation" => "devdocs.md"
     ],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(;
         "Makie integration" => "makie.md",
         "Developer documentation" => "devdocs.md"
     ],
+    warnonly=true,
 )
 
 deploydocs(;

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Makie integration" => "makie.md"
     ],
 )
 

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -7,3 +7,10 @@ FlyThroughPaths operates on the [`ViewState`](@ref) model.  In order to implemen
 - `set_view!(obj, viewstate::ViewState)`: set the camera to the given `ViewState`.
 
 Integration is already implemented for Makie; you can see that in `ext/FlyThroughPathsMakieExt.jl`.  The first ~20 lines are the most instructive, beyond which lie utility functions and visualization specializations.
+
+## The `PathChange` interface
+
+```@docs
+PathChange
+duration
+```

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -1,0 +1,9 @@
+# Developer documentation
+
+## Implementing support for FlyThroughPaths
+
+FlyThroughPaths operates on the [`ViewState`](@ref) model.  In order to implement support for this in a plotting package, you must implement dispatches for the following two functions:
+- `capture_view(obj)::ViewState`: extract the current `ViewState`, i.e., camera settings, from `obj`.
+- `set_view!(obj, viewstate::ViewState)`: set the camera to the given `ViewState`.
+
+Integration is already implemented for Makie; you can see that in `ext/FlyThroughPathsMakieExt.jl`.  The first ~20 lines are the most instructive, beyond which lie utility functions and visualization specializations.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,9 +6,156 @@ CurrentModule = FlyThroughPaths
 
 Documentation for [FlyThroughPaths](https://github.com/HolyLab/FlyThroughPaths.jl).
 
-```@index
+
+All of the examples below assume you've loaded the package with `using FlyThroughPaths`.
+
+## Generic tools
+
+### Representation of paths and view state
+
+Paths are parametrized by time `t`, represented in units of seconds. All paths implicitly start at `t=0`.
+
+The representation of view state is independent of any particular plotting package, although our parametrization is inspired by [Makie's 3D camera](https://docs.makie.org/stable/explanations/cameras/#3d_camera):
+
+- `eyeposition`: the 3d coordinates of the camera
+- `lookat`: the 3d coordinates of the point of the camera's "focus" (center of gaze)
+- `upvector`: the 3d direction that will correspond to the top of the view. Any component of this vector in the direction of `lookat - eyeposition` is ignored/discarded.
+- `fov`: the angle (in degrees) of the cone centered on `lookat - eyeposition` that should be captured.
+
+Set these as follows:
+
+```julia
+julia> state = ViewState(eyeposition=[-10, 0, 0], lookat=[0, 0, 0], upvector=[0, 0, 1], fov=45)
+ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
 ```
 
-```@autodocs
-Modules = [FlyThroughPaths]
+You can set just a subset of these:
+```julia
+julia> newstate = ViewState(eyeposition=[-5, 0, 0])
+ViewState{Float32}(eyeposition=[-5.0, 0.0, 0.0])
+```
+
+This syntax is often used for updating a previous view; for the unspecified settings, the previous value is left intact.
+
+
+### Initializing a path
+
+```julia
+julia> path = Path(state)
+Path{Float32}(ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0), FlyThroughPaths.PathChange{Float32}[])
+```
+
+The path starts at `state` at time `t=0`.
+
+### Evaluating at a particular time
+
+Once you have a path, you can get the current `ViewState` with `path(t)`:
+
+```julia
+julia> path(0)
+ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+
+julia> path(10)
+ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+```
+
+So far, nothing much is happening. Things get more interesting when we add movements.
+
+### Holding steady
+
+The simplest thing you can do is insert a pause:
+
+```julia
+julia> path2 = path * Pause(5)
+Path{Float32}(ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0), FlyThroughPaths.PathChange{Float32}[Pause{Float32}(5.0f0, nothing)])
+```
+
+The view will hold steady for 5 seconds. Typically you add `Pause` when you also plan to add other movements later.
+
+### Moving the camera, option 1: constrained movements
+
+This option is typically used for things like rotations around a center point.
+
+```julia
+julia> path2 = path * ConstrainedMove(5, newstate; constraint=:none, speed=:constant)
+Path{Float32}(ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0), FlyThroughPaths.PathChange{Float32}[ConstrainedMove{Float32}(5.0f0, ViewState{Float32}(eyeposition=[-5.0, 0.0, 0.0]), :none, :constant, nothing)])
+```
+
+This indicates that over a 5-second period, the camera state gradually adopts any values specified in `newstate`.
+
+```julia
+julia> path2(0)
+ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+
+julia> path2(5)
+ViewState{Float32}(eyeposition=[-5.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+
+julia> path2(2.5)
+ViewState{Float32}(eyeposition=[-7.5, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+```
+
+Keyword options include:
+
+- `constraint` (`:none` or `:rotation`): specify a value to keep constant during motion. `:rotation` performs a rotation around `lookat`. Note that if the separation between `eyeposition` and `lookat` is not constant, then the trajectory will be elliptical rather than circular.
+- `speed` controls how the change is made across time:
+  - `:constant`: speed is instantaneously set to a new constant value that will arrive at the endpoint at the specified time
+  - `:sinusoidal`: speed will initially increase (starting at a speed of 0), achieve a maximum at the midpoint, and then decrease back to 0.
+
+
+### Moving the camera, option 2: Bezier movements
+
+With this option, you can approximately simulate the feeling of flight, preserving momentum:
+
+```
+path2 = path * BezierMove(Δt::Real, P1::ViewState, P2::ViewState...)
+```
+
+where a `bezier` path is specified as indicated in this diagram:
+
+![bezier diagram](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Bezier_curve.svg/640px-Bezier_curve.svg.png)
+
+The starting state, `P0` in the diagram, is taken from the endpoint of `path`. Over the next `Δt` seconds, one then moves towards the last `ViewState` argument of `bezier`, orienting successively towards any prior arguments. Probably the most robust option is to use `bezier(Δt, P1, P2, P3)`, which can be interpreted as "depart `P0` traveling towards `P1`, and arrive at `P3` as if you had come from `P2`." The view does not actually pass through `P1` and `P2`, but these set the initial and final tangents of the curve.
+
+To see this in action, let's create a move that "rotates" around the origin but moves outward (to a more distant orbit) on its way there:
+
+```julia
+julia> move = BezierMove(5, ViewState(eyeposition=[0, 10, 0]), [ViewState(eyeposition=[-20, 20, 0])])
+BezierMove{Float32}(5.0f0, ViewState{Float32}(eyeposition=[0.0, 10.0, 0.0]), ViewState{Float32}[ViewState{Float32}(eyeposition=[-20.0, 20.0, 0.0])], nothing)
+
+julia> path2 = path * move;
+
+julia> path2(2.5)
+ViewState{Float32}(eyeposition=[-12.5, 12.5, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+```
+
+## Backend-specific tools
+
+These require interaction with a plotting package supported by one of the extensions. Currently supported:
+
+- [Makie](https://docs.makie.org/stable/)
+
+You need to load the visualization package, e.g., `using GLMakie`, in your session before any of the commands below will work.
+
+### Capturing the current view state
+
+This can be handy for constructing a path, for example you can interactively set the approximate position and view parameters and then query them for use by the tools above.
+
+```julia
+state = capture_view(scene)
+```
+
+`state` is a `ViewState` object.
+
+### Setting the current view state
+
+```julia
+oldstate = set_view!(camera, path, t)
+```
+
+This updates the current `camera` settings from `path` at time `t`.
+
+### Displaying the path
+
+```julia
+plot(path)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,6 +9,8 @@ Documentation for [FlyThroughPaths](https://github.com/HolyLab/FlyThroughPaths.j
 
 All of the examples below assume you've loaded the package with `using FlyThroughPaths`.
 
+# Quick start
+
 ## Generic tools
 
 ### Representation of paths and view state
@@ -24,15 +26,14 @@ The representation of view state is independent of any particular plotting packa
 
 Set these as follows:
 
-```julia
-julia> state = ViewState(eyeposition=[-10, 0, 0], lookat=[0, 0, 0], upvector=[0, 0, 1], fov=45)
-ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+```@repl main
+using FlyThroughPaths
+state = ViewState(eyeposition=[-10, 0, 0], lookat=[0, 0, 0], upvector=[0, 0, 1], fov=45)
 ```
 
 You can set just a subset of these:
-```julia
-julia> newstate = ViewState(eyeposition=[-5, 0, 0])
-ViewState{Float32}(eyeposition=[-5.0, 0.0, 0.0])
+```@repl main
+newstate = ViewState(eyeposition=[-5, 0, 0])
 ```
 
 This syntax is often used for updating a previous view; for the unspecified settings, the previous value is left intact.
@@ -40,9 +41,8 @@ This syntax is often used for updating a previous view; for the unspecified sett
 
 ### Initializing a path
 
-```julia
-julia> path = Path(state)
-Path{Float32}(ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0), FlyThroughPaths.PathChange{Float32}[])
+```@repl main
+path = Path(state)
 ```
 
 The path starts at `state` at time `t=0`.
@@ -51,12 +51,10 @@ The path starts at `state` at time `t=0`.
 
 Once you have a path, you can get the current `ViewState` with `path(t)`:
 
-```julia
-julia> path(0)
-ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+```@repl main
+path(0)
 
-julia> path(10)
-ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+path(10)
 ```
 
 So far, nothing much is happening. Things get more interesting when we add movements.
@@ -65,9 +63,8 @@ So far, nothing much is happening. Things get more interesting when we add movem
 
 The simplest thing you can do is insert a pause:
 
-```julia
-julia> path2 = path * Pause(5)
-Path{Float32}(ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0), FlyThroughPaths.PathChange{Float32}[Pause{Float32}(5.0f0, nothing)])
+```@repl main
+path2 = path * Pause(5)
 ```
 
 The view will hold steady for 5 seconds. Typically you add `Pause` when you also plan to add other movements later.
@@ -76,22 +73,16 @@ The view will hold steady for 5 seconds. Typically you add `Pause` when you also
 
 This option is typically used for things like rotations around a center point.
 
-```julia
-julia> path2 = path * ConstrainedMove(5, newstate; constraint=:none, speed=:constant)
-Path{Float32}(ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0), FlyThroughPaths.PathChange{Float32}[ConstrainedMove{Float32}(5.0f0, ViewState{Float32}(eyeposition=[-5.0, 0.0, 0.0]), :none, :constant, nothing)])
+```@repl main
+path2 = path * ConstrainedMove(5, newstate; constraint=:none, speed=:constant)
 ```
 
 This indicates that over a 5-second period, the camera state gradually adopts any values specified in `newstate`.
 
-```julia
-julia> path2(0)
-ViewState{Float32}(eyeposition=[-10.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
-
-julia> path2(5)
-ViewState{Float32}(eyeposition=[-5.0, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
-
-julia> path2(2.5)
-ViewState{Float32}(eyeposition=[-7.5, 0.0, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+```@repl main
+path2(0)
+path2(5)
+path2(2.5)
 ```
 
 Keyword options include:
@@ -118,14 +109,10 @@ The starting state, `P0` in the diagram, is taken from the endpoint of `path`. O
 
 To see this in action, let's create a move that "rotates" around the origin but moves outward (to a more distant orbit) on its way there:
 
-```julia
-julia> move = BezierMove(5, ViewState(eyeposition=[0, 10, 0]), [ViewState(eyeposition=[-20, 20, 0])])
-BezierMove{Float32}(5.0f0, ViewState{Float32}(eyeposition=[0.0, 10.0, 0.0]), ViewState{Float32}[ViewState{Float32}(eyeposition=[-20.0, 20.0, 0.0])], nothing)
-
-julia> path2 = path * move;
-
-julia> path2(2.5)
-ViewState{Float32}(eyeposition=[-12.5, 12.5, 0.0], lookat=[0.0, 0.0, 0.0], upvector=[0.0, 0.0, 1.0], fov=45.0)
+```@repl main
+move = BezierMove(5, ViewState(eyeposition=[0, 10, 0]), [ViewState(eyeposition=[-20, 20, 0])])
+path2 = path * move;
+path2(2.5)
 ```
 
 ## Backend-specific tools
@@ -141,7 +128,7 @@ You need to load the visualization package, e.g., `using GLMakie`, in your sessi
 This can be handy for constructing a path, for example you can interactively set the approximate position and view parameters and then query them for use by the tools above.
 
 ```julia
-state = capture_view(scene)
+state = capture_view(scenelike::Union{Scene, LScene})
 ```
 
 `state` is a `ViewState` object.
@@ -149,7 +136,7 @@ state = capture_view(scene)
 ### Setting the current view state
 
 ```julia
-oldstate = set_view!(camera, path, t)
+oldstate = set_view!(scenelike, path, t)
 ```
 
 This updates the current `camera` settings from `path` at time `t`.

--- a/docs/src/makie.md
+++ b/docs/src/makie.md
@@ -77,5 +77,14 @@ end
 ```
 ![A zooming view of a surface](path_zoom.mp4)
 
+## Visualizing the camera's path
+
+```@example simple
+f2, a2, p2 =  surface(-8..8, -8..8, Makie.peaks())
+FlyThroughPaths.plotcamerapath!(a2, path, 7)
+Makie.rotate_cam!(a2.scene, 0, pi/4, 0)
+f2
+```
+
 ## Bézier paths
 

--- a/docs/src/makie.md
+++ b/docs/src/makie.md
@@ -81,9 +81,16 @@ end
 
 ```@example simple
 f2, a2, p2 =  surface(-8..8, -8..8, Makie.peaks())
-FlyThroughPaths.plotcamerapath!(a2, path, 7)
+pathplot = FlyThroughPaths.plotcamerapath!(a2, path, 7)
 Makie.rotate_cam!(a2.scene, 0, pi/4, 0)
 f2
+```
+
+We can also animate the path to understand it more:
+```@example simple
+record(f2, "camera_path.mp4", LinRange(0, 5, 150); framerate = 30) do t
+    pathplot.time[] = t
+end
 ```
 
 ## Bézier paths

--- a/docs/src/makie.md
+++ b/docs/src/makie.md
@@ -92,6 +92,7 @@ record(f2, "camera_path.mp4", LinRange(0, 5, 150); framerate = 30, update = fals
     pathplot.time[] = t
 end
 ```
+![](camera_path.mp4)
 
 ## Visualizing the viewing frustum
 ```@example simple

--- a/docs/src/makie.md
+++ b/docs/src/makie.md
@@ -1,0 +1,81 @@
+# Makie integration
+
+FlyThroughPaths.jl is integrated with Makie.jl `LScene`s, which are 
+the standard axis for 3-D plots.
+
+## Orbiting a point
+
+Here's a simple example:
+
+```@example simple
+using GLMakie, FlyThroughPaths
+
+fig, ax, plt = surface(-8..8, -8..8, Makie.peaks())
+```
+
+Now, we can use FlyThroughPaths to orbit the camera around the 
+current `lookat` point, by changing the eye position.
+
+### Extracting the view
+
+First, we extract the initial view state from the axis `ax`.
+
+```@example simple
+view0 = capture_view(ax)
+```
+Note that this `ViewState` is a Float32 object, since that's the space
+Makie cameras work in.  If you want this to be Float64, you can 
+simply `convert(ViewState{Float64}, view0)`.
+
+### Creating a path
+
+Next, we create a `Path` with this initial state.
+```@example simple
+path = Path(view0)
+```
+We've now created a `Path` object with an initial state `view0`.  
+`Path`s contain instructions for how to move the camera in time, and 
+you can add to a path by `path * new_component`.
+
+```@example simple
+path = path * ConstrainedMove(
+    5,          # the amount of time the move should take
+    ViewState(eyeposition = [0, 0, 46]), # the final state of the camera
+    :rotation,  # the rotation constraint (can also be `:none`)
+    :constant   # the type of interpolation (can also be `:sinusoidal`)
+)
+```
+Here, we've added a `ConstrainedMove` to the path, which moves the 
+camera to the point `[0, 0, 46]` in 5 seconds.
+
+The reasons I chose these particular coordinates was to preserve the 
+norm (`norm(view0.eyeposition) ≈ 46`, `norm(new) ≈ 46`), so that the 
+rotation looks as elliptical as it can.
+
+### Animating the camera
+
+Now, we can use Makie's `record` function to record an animation with 
+this:
+```@example simple
+record(fig, "path.mp4", LinRange(0, 5, 150); framerate = 30) do t
+    set_view!(ax, path(t))
+end
+```
+![A rotating view of a surface](path.mp4)
+
+### Zooming
+
+We can also zoom in by changing the field of view, `fov`:
+```@example simple
+path = path * ConstrainedMove(5, ViewState(; fov = 10), :none, :sinusoidal)
+```
+In this case, we chose sinusoidal interpolation to get a smooth zoom.
+```@example simple
+record(fig, "path_zoom.mp4", LinRange(5, 10, 150); framerate = 30) do t
+    set_view!(ax, path(t))
+end
+```
+![A zooming view of a surface](path_zoom.mp4)
+
+## Bézier paths
+

--- a/ext/FlyThroughPathsMakieExt.jl
+++ b/ext/FlyThroughPathsMakieExt.jl
@@ -70,9 +70,9 @@ function Makie.plot!(plot::PlotCameraPath)
 
     current_viewstate_obs = lift(plot, plot.path, plot.time) do path, time
         current_viewstate = path(time)
-        eyeposition_obs.val = current_viewstate.eyeposition |> Point3d
-        lookat_obs.val = current_viewstate.lookat |> Point3d
-        viewdir = (current_viewstate.lookat - current_viewstate.eyeposition)
+        eyeposition_obs.val = Point3d(current_viewstate.eyeposition)
+        lookat_obs.val = Point3d(current_viewstate.lookat)
+        viewdir = current_viewstate.lookat - current_viewstate.eyeposition
         viewdir_obs.val = Point3d(viewdir)
         notify(eyeposition_obs)
         notify(lookat_obs)

--- a/ext/FlyThroughPathsMakieExt.jl
+++ b/ext/FlyThroughPathsMakieExt.jl
@@ -11,11 +11,18 @@ FlyThroughPaths.capture_view(scene::Scene) = capture_view(cameracontrols(scene))
 FlyThroughPaths.capture_view(axis::Makie.AbstractAxis) = capture_view(axis.scene) # by convention, all axes have a `ax.scene` that holds the scene with content
 
 function FlyThroughPaths.set_view!(scene::Scene, view::ViewState)
-    Makie.update_cam!(scene, view.eyeposition, view.lookat, view.upvector)
-    cameracontrols(scene).fov[] = view.fov[]
+    # Extract the camera controls from the Scene
+    cam = Makie.cameracontrols(scene)
+    @assert cam isa Makie.Camera3D "`cameracontrols(scene)` must be a `Camera3D`, we don't support any other camera.  Got $(typeof(cam))."
+    # Set the appropriate fields
+    cam.eyeposition[] = view.eyeposition
+    cam.lookat[] = view.lookat
+    cam.upvector[] = view.upvector
+    cam.fov[] = view.fov
+    # Update the camera using the new controls
+    Makie.update_cam!(scene, cam)
     return scene
 end
-
 FlyThroughPaths.set_view!(axis::Makie.AbstractAxis, view::ViewState) = set_view!(axis.scene, view)
 
 end

--- a/ext/FlyThroughPathsMakieExt.jl
+++ b/ext/FlyThroughPathsMakieExt.jl
@@ -80,8 +80,8 @@ function Makie.plot!(plot::PlotCameraPath)
         current_viewstate
     end
 
-
-
+    # Now that we have the Observables defined, 
+    # we can create the plots!
     lines!(
         plot, 
         eyepositions_obs;
@@ -89,7 +89,6 @@ function Makie.plot!(plot::PlotCameraPath)
         colormap = plot.colormap, 
         linewidth = plot.linewidth, 
         linestyle = plot.linestyle,
-
     )
     arrows!(
         plot, 

--- a/ext/FlyThroughPathsMakieExt.jl
+++ b/ext/FlyThroughPathsMakieExt.jl
@@ -26,3 +26,71 @@ end
 FlyThroughPaths.set_view!(axis::Makie.AbstractAxis, view::ViewState) = set_view!(axis.scene, view)
 
 end
+
+
+# Define the recipe
+import FlyThroughPaths: plotcamerapath, plotcamerapath!
+@recipe(PlotCameraPath, path, time) do scene
+    Attributes(
+        color = Makie.inherit(scene, :color, :black),
+        linewidth = Makie.inherit(scene, :linewidth, 1.0),
+        linestyle = Makie.inherit(scene, :linestyle, :solid),
+        camera_marker = Makie.inherit(scene, :marker, :none),
+        camera_color = Makie.inherit(scene, :color, :black),
+        camera_markersize = Vec3f(2, 2, 3),
+        density = 30, # points per second
+        cycle = [:color,],
+    )
+end
+
+using Makie: Point3d
+function Makie.plot!(plot::PlotCameraPath)
+    # Main.@infiltrate
+
+    eyepositions_obs = lift(plot, plot.path, plot.density) do path, density
+        tend = FlyThroughPaths.duration(path)
+        trange = LinRange(0, tend, round(Int, tend*density))
+        Makie.Point3d.(getproperty.(path.(trange), :eyeposition))
+    end
+    notify(plot.density) # run the `onany` once
+
+    eyeposition_obs = Observable{Point3d}(plot.path[](0).eyeposition)
+    lookat_obs = Observable{Point3d}(plot.path[](0).lookat)
+    viewdir_obs = Observable{Point3d}(plot.path[](0).lookat)
+
+    current_viewstate_obs = lift(plot, plot.path, plot.time) do path, time
+        current_viewstate = path(time)
+        eyeposition_obs.val = current_viewstate.eyeposition |> Point3d
+        lookat_obs.val = current_viewstate.lookat |> Point3d
+        viewdir = (current_viewstate.lookat - current_viewstate.eyeposition)
+        viewdir_obs.val = Point3d(viewdir)
+        notify(eyeposition_obs)
+        notify(lookat_obs)
+        notify(viewdir_obs)
+        current_viewstate
+    end
+
+
+
+    lines!(
+        plot, 
+        eyepositions_obs;
+        color = plot.color, 
+        linewidth = plot.linewidth, 
+        linestyle = plot.linestyle
+    )
+    arrows!(
+        plot, 
+        @lift([$eyeposition_obs]), 
+        @lift([$viewdir_obs]);
+        color = plot.camera_color, 
+        arrowsize = plot.camera_markersize, 
+        normalize = true, 
+        shading = Makie.MultiLightShading,
+        align = :headstart,
+    )
+
+
+end
+
+end

--- a/src/FlyThroughPaths.jl
+++ b/src/FlyThroughPaths.jl
@@ -12,6 +12,7 @@ function set_view! end
 include("viewstate.jl")
 include("pathchange.jl")
 include("path.jl")
+include("recipe.jl")
 
 function __init__()
     if isdefined(Base.Experimental, :register_error_hint)

--- a/src/FlyThroughPaths.jl
+++ b/src/FlyThroughPaths.jl
@@ -14,7 +14,7 @@ include("path.jl")
 function __init__()
     if isdefined(Base.Experimental, :register_error_hint)
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
-            if exc.f === capture_view || exc.f === set_view!
+            if exc.f in (capture_view, set_view!, plotcamerapath, plotcamerapath!)
                 print(io, '\n', exc.f, " requires that you first load a plotting backend (e.g., `using GLMakie`)")
             end
         end

--- a/src/FlyThroughPaths.jl
+++ b/src/FlyThroughPaths.jl
@@ -6,13 +6,10 @@ export ViewState, Path, Pause, ConstrainedMove, BezierMove
 # exports for the extensions
 export capture_view, set_view!
 
-function capture_view end
-function set_view! end
-
+include("interfaces.jl")
 include("viewstate.jl")
 include("pathchange.jl")
 include("path.jl")
-include("recipe.jl")
 
 function __init__()
     if isdefined(Base.Experimental, :register_error_hint)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -1,0 +1,44 @@
+########################################
+#         PathChange interface         #
+########################################
+"""
+    duration(p)
+
+Return the duration of the path or path change as a `Number`.
+
+For an object of type `Path{T}` or `PathChange{T}`, this function
+will return a number of type `T`.
+"""
+function duration end
+
+########################################
+#      Plotting backend interface      #
+########################################
+"""
+    capture_view(object)
+
+Return a `ViewState` that captures the current camera settings
+of the object.  
+
+This is currently implemented for Makie.jl `Scene`s and `LScene`s, but
+can be extended to arbitrary backends.
+"""
+function capture_view end
+
+"""
+    set_view!(object, viewstate)
+
+Set the camera settings of the object to the given `ViewState`.
+
+This is currently implemented for Makie.jl `Scene`s and `LScene`s, but
+can be extended to arbitrary backends.
+"""
+function set_view! end
+
+########################################
+#       Diagnostic visualization       #
+########################################
+# The functions below are specific to Makie.
+function plotcamerapath end
+function plotcamerapath! end
+# If creating a Plots recipe, use seriestype=:plotcamerapath

--- a/src/path.jl
+++ b/src/path.jl
@@ -10,6 +10,8 @@ function Base.:*(path::Path{R}, change::PathChange{S}) where {R,S}
     Path{T}(path.initialview, PathChange{T}[path.changes..., change])
 end
 
+duration(path::Path{T}) where T = sum(duration, path.changes; init = zero(T))
+
 function (path::Path{T})(t) where T
     view = path.initialview
     tend = zero(T)

--- a/src/path.jl
+++ b/src/path.jl
@@ -1,8 +1,23 @@
+"""
+    struct Path{T}
+
+A `Path` is a sequence of `PathChange`s, beginning from some `initialview::ViewState`.
+It is callable with a single parameter `t`, which is the time since the start of the path at `t=0`.
+It returns the `ViewState` at time `t`.
+
+To add a new `PathChange` to a `Path`, use the `*` operator.  This is non-mutating and will construct a new path!
+"""
 struct Path{T}
     initialview::ViewState{T}
     changes::Vector{PathChange{T}}
 end
 Path{T}(initialview::ViewState) where T = Path{T}(initialview, PathChange{T}[])
+
+"""
+    Path(initialview::ViewState{T}) where T
+
+Construct a `Path` that starts at `initialview`.
+"""
 Path(initialview::ViewState{T}) where T = Path{T}(initialview)
 
 function Base.:*(path::Path{R}, change::PathChange{S}) where {R,S}

--- a/src/pathchange.jl
+++ b/src/pathchange.jl
@@ -6,14 +6,28 @@ The supertype for all path changes.
 ## Interface
 
 All subtypes of `PathChange` must be callable with the signature
-`(::PathChange)(t::Real)::ViewState`.
+`(::PathChange)(t::Real)::ViewState`.  Here `t` is the _relative_
+time, that is, `t=0` corresponds to the absolute time point where
+the particular `PathChange` that is being called begins.
 
-Additionally, they must implement the following functions:
+All `PathChange` subtypes must implement the following functions:
 - `duration(::PathChange{T})::T`
 - `target(oldviewstate::ViewState, c::PathChange)::ViewState`, if applicable.
+
+By convention, each `PathChange` subtype includes an `action` field.
+This is a callback callable that takes a single argument `t`, which is 
+the relative time within the `PathChange`, and performs some action, 
+such as updating some state variable.  If absolute time is desired,
+it's best to implment that in the outer animation loop, and not as 
+an `action` callback.
 """
 abstract type PathChange{T<:Real} end
 
+"""
+    Pause(duration, [action])
+
+Pause at the current position for `duration`.
+"""
 struct Pause{T} <: PathChange{T}
     duration::T
     action

--- a/src/pathchange.jl
+++ b/src/pathchange.jl
@@ -1,3 +1,17 @@
+"""
+    abstract type PathChange{T <: Real} 
+
+The supertype for all path changes.
+
+## Interface
+
+All subtypes of `PathChange` must be callable with the signature
+`(::PathChange)(t::Real)::ViewState`.
+
+Additionally, they must implement the following functions:
+- `duration(::PathChange{T})::T`
+- `target(oldviewstate::ViewState, c::PathChange)::ViewState`, if applicable.
+"""
 abstract type PathChange{T<:Real} end
 
 struct Pause{T} <: PathChange{T}

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -1,0 +1,2 @@
+function plotcamerapath end
+function plotcamerapath! end

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -1,2 +1,0 @@
-function plotcamerapath end
-function plotcamerapath! end


### PR DESCRIPTION
- Adds a `plotcamerapath` recipe which has a colored line (representing time) and an arrow (representing the camera).
	- TODO: add viewing frustum
- Runs the documentation build under a virtual framebuffer (`xvfb`) so we can use GLMakie on CI
- Fixes the Makie camera integration so that everything is updated correctly
- Adds a demo using rotation and zoom in GLMakie
- Defines `duration(path)` for paths as well