### PR TITLE
[WIP] Videos displayed directly from example blocks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,10 @@ jobs:
           xvfb-run -s '-screen 0 1024x768x24' julia --project=docs -e '
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.add(name = "DocumenterVitepress", rev = "master")
+            Pkg.add([
+              PackageSpec(name = "DocumenterVitepress", rev = "master"), 
+              PackageSpec(url = "https://github.com/asinghvi17/Documenter.jl", rev = "patch-4"),
+            ])
             Pkg.instantiate()'
         env:
           DISPLAY: ':0'

--- a/docs/src/makie.md
+++ b/docs/src/makie.md
@@ -57,9 +57,11 @@ rotation looks as elliptical as it can.
 Now, we can use Makie's `record` function to record an animation with 
 this:
 ```@example simple
-record(fig, "path.mp4", LinRange(0, 5, 150); framerate = 30) do t
+io = Record(fig, LinRange(0, 5, 150); framerate = 30) do t
     set_view!(ax, path(t))
 end
+# save("video.mp4", io)
+io # hide
 ```
 ![A rotating view of a surface](path.mp4)
 


### PR DESCRIPTION
This aims to test whether we can get away without displaying videos.  If so, then life becomes easier not only for FlyThroughPaths but also for a potential future integration with [OhMyCards](https://github.com/asinghvi17/OhMyCards.jl) as used in [GeoMakie's example gallery](https://geo.makie.org/v0.7.3/examples)